### PR TITLE
change buffer size for m1s_xram_audio_init

### DIFF
--- a/c906_app/audio_recording/main.c
+++ b/c906_app/audio_recording/main.c
@@ -15,7 +15,7 @@ void main()
     printf("Audio init..\r\n");
     uint16_t *buff = pvPortMalloc(AUDIO_BUFF_SIZE * 2);
     assert(buff);
-    m1s_xram_audio_init(buff, AUDIO_BUFF_SIZE * 2);
+    m1s_xram_audio_init(buff, AUDIO_BUFF_SIZE);
 
     uint16_t *rec_buff;
     uint32_t rec_buff_size;


### PR DESCRIPTION
I might be wrong on this, but when I used the example code as-is, I would get memory corruption.  Though I haven't found any documentation on the SDK, I suspect that the buffer size parameter of m1s_xram_audio_init should not be AUDIO_BUFF_SIZE*2.  When I changed it to AUDIO_BUFF_SIZE, the memory corruption went away.